### PR TITLE
Resolve scroll re-snap issue with CSS-only approach

### DIFF
--- a/examples/astro/src/pages/dynamic-content.astro
+++ b/examples/astro/src/pages/dynamic-content.astro
@@ -66,7 +66,8 @@ import SheetConfigPanel from "../components/SheetConfigPanel.astro";
       const hours = String(now.getHours()).padStart(2, "0");
       const minutes = String(now.getMinutes()).padStart(2, "0");
       const seconds = String(now.getSeconds()).padStart(2, "0");
-      timeElement.textContent = `${hours}:${minutes}:${seconds}`;
+      const wrapperElementTag = now.getSeconds() % 2 === 0 ? "span" : "strong";
+      timeElement.innerHTML = `<${wrapperElementTag}>${hours}:${minutes}:${seconds}</${wrapperElementTag}>`;
     }
   }
 

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -44,19 +44,6 @@ const styles = css`
     }
   }
 
-  /* 
-    Disable snap alignment when sheet has reached the top and being scrolled
-    to prevent snapping back to the top when the user scrolls the sheet on
-    certain browsers (e.g. Firefox).
-  */
-  :host([data-sheet-snap-position="-1"]) {
-    .sheet,
-    .snap::before,
-    ::slotted([slot="snap"])::before {
-      scroll-snap-align: none;
-    }
-  }
-
   .snap,
   ::slotted([slot="snap"]) {
     position: relative;
@@ -103,9 +90,6 @@ const styles = css`
     &[data-snap="0"] {
       top: -1px; /** Extra -1px needed for Safari */
     }
-    &[data-snap="-1"] {
-      top: 2px; /** Extra +1px needed for Safari */
-    }
     &[data-snap="1"] {
       top: 1px;
     }
@@ -124,6 +108,19 @@ const styles = css`
     overflow: clip;
     scroll-snap-align: var(--snap-point-align, start);
     pointer-events: all;
+  }
+
+  /* 
+    Needed for Safari/Firefox to prevent abrupt scroll re-snapping in case the
+    sheet DOM content is dynamically changed. Without this, these browsers would
+    re-snap to the start of the .sheet element.
+    See related spec: https://drafts.csswg.org/css-scroll-snap-1/#re-snap
+  */
+  .sheet::after {
+    display: block;
+    position: static;
+    scroll-snap-align: var(--snap-point-align, end);
+    content: "";
   }
 
   .sheet-header {
@@ -433,7 +430,6 @@ export const template: string = /* HTML */ `
   <div class="sentinel" data-snap="0"></div>
   <div class="sheet-wrapper">
     <aside class="sheet" part="sheet" data-snap="0">
-      <div class="sentinel" data-snap="-1"></div>
       <header class="sheet-header" part="header">
         <div class="handle" part="handle"></div>
         <slot name="header"></slot>


### PR DESCRIPTION
## Description

Replaces the JavaScript-based scroll snap toggling with a CSS-only solution to prevent abrupt scroll re-snapping when the sheet's DOM content is dynamically changed. The new approach uses an `::after` pseudo-element on the `.sheet` element with `scroll-snap-align` set to `end`. This pseudo-element appears as the last child of the sheet's inner content, which is sufficient to prevent the abrupt scroll re-snapping issue on Safari and Firefox that otherwise occurs when the sheet's DOM content changes dynamically.

The previous JavaScript-based approach relied on observing when the sheet was fully expanded (:host([data-sheet-snap-position="-1"])), which toggled scroll-snap-align on and off for all snap alignment elements. This had a significant drawback: quick swipes back to the sheet's beginning ignored any `scroll-snap-stop: always` rules set on the snap points, since browsers only respect re-enabled snap alignment starting from the next scroll gesture.

Fixes #6

## Checklist

- [x] My code follows the code guidelines of this project
