### PR TITLE
Fix scroll snapping in nested-scroll mode

### DIFF
--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -116,7 +116,7 @@ const styles = css`
     re-snap to the start of the .sheet element.
     See related spec: https://drafts.csswg.org/css-scroll-snap-1/#re-snap
   */
-  .sheet::after {
+  :host(:not([nested-scroll])) .sheet::after {
     display: block;
     position: static;
     scroll-snap-align: var(--snap-point-align, end);


### PR DESCRIPTION
## Description

Fixes scroll snapping in nested-scroll mode that was broken by the #7 that introduced the new CSS-only workaround for the re-snapping issue. Updates the re-snapping CSS workaround to only apply when not using nested-scroll mode.

## Checklist

- [x] My code follows the code guidelines of this project
