### PR TITLE
Prevent horizontal touch scrolling of sheet overflow on iOS Safari

### DIFF
--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -200,6 +200,8 @@ const styles = css`
       /* Prevent rubberband effect */
       overscroll-behavior-x: none;
       scrollbar-width: none;
+      /* Prevent horizontal scrolling using touch gestures */
+      touch-action: pan-y pinch-zoom;
 
       &::after {
         display: block;


### PR DESCRIPTION
## Description

Prevents horizontal touch scrolling of the sheet overflow on iOS Safari that occurs due the workaround used for the Webkit bug https://bugs.webkit.org/show_bug.cgi?id=183870

## Checklist

- [x] My code follows the code guidelines of this project
