### PR TITLE
Improve initial snap reliability and limit snap-type reset to Safari

### DIFF
--- a/src/web/bottom-sheet-dialog-manager.template.ts
+++ b/src/web/bottom-sheet-dialog-manager.template.ts
@@ -35,22 +35,11 @@ const styles = css`
     transition:
       translate 0.5s ease-out,
       overlay 0.5s ease-out allow-discrete,
-      display var(--display-transition-duration, 0.5s) ease-out allow-discrete;
+      display 0.5s ease-out allow-discrete;
   }
 
   :host([data-sheet-snap-position="2"]) ::slotted(dialog:not([open])) {
     transition: none;
-  }
-
-  /** Safari overrides */
-  @supports (-webkit-touch-callout: none) or (-webkit-hyphens: none) {
-    ::slotted(dialog) {
-      /* 
-        For Safari we must user shorter duration for display property or otherwise
-        the bottom sheet will not snap properly to the initial target on open.
-      */
-      --display-transition-duration: 0.1s;
-    }
   }
 `;
 


### PR DESCRIPTION
## Description

Previously, the initial-snap animation used a very short duration 0.01s / 0.1s (on Safari) which was unreliable when the browser CPU got heavily throttled. Switching to 0.5s gives the browser more time to snap to the correct initial position consistently across different browsers.

The scroll-snap-type temporary reset trick (needed to prevent scroll position from resetting on Safari when snap-align is re-enabled) is now applied via a CSS variable (--snap-type-initial-reset) that is only set to none inside the Safari @supports block, leaving the behavior unchanged on other browsers.

## Checklist

- [x] My code follows the code guidelines of this project
