### PR TITLE
Switch from named to anonymous scroll timelines for Firefox compat

### DIFF
--- a/examples/astro/src/pages/popover.astro
+++ b/examples/astro/src/pages/popover.astro
@@ -106,6 +106,7 @@ import { bottomSheetTemplate } from "pure-web-bottom-sheet/ssr";
     width: auto;
     top: auto;
     background: none;
+    scroll-timeline: --sheet-timeline y;
     &::backdrop {
       background-color: rgba(0, 0, 0, 0.5);
       animation: fade-in linear forwards;

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -247,6 +247,8 @@ const styles = css`
       bottom: 0;
       flex-direction: column;
       justify-content: end;
+      /* Needed for Firefox to properly render sticky items due to using contain: strict */
+      content-visibility: auto;
       /* Fixes scroll-chaining issue on Firefox when sheet content is scrollable */
       contain: strict;
       height: 100%;
@@ -311,13 +313,9 @@ const styles = css`
   }
 
   @supports ((animation-timeline: scroll()) and (animation-range: 0% 100%)) {
-    :host {
-      scroll-timeline: --sheet-timeline y;
-    }
-
     :host([nested-scroll]) .sheet {
       animation: expand-sheet-height linear forwards;
-      animation-timeline: --sheet-timeline;
+      animation-timeline: scroll();
     }
 
     @keyframes expand-sheet-height {
@@ -331,7 +329,7 @@ const styles = css`
 
     :host([nested-scroll][expand-to-scroll]) .sheet-content {
       animation: overflow-y-toggle linear forwards;
-      animation-timeline: --sheet-timeline;
+      animation-timeline: scroll();
     }
 
     @keyframes overflow-y-toggle {
@@ -354,17 +352,17 @@ const styles = css`
         */
         transform: translateY(var(--sheet-timeline-at-scroll-start, 0));
         animation: translate-sheet linear forwards;
-        animation-timeline: --sheet-timeline;
+        animation-timeline: scroll();
       }
 
       .sheet-content {
         animation: translate-sheet-content linear forwards;
-        animation-timeline: --sheet-timeline;
+        animation-timeline: scroll();
       }
 
       .sheet-footer {
         animation: translate-footer linear forwards;
-        animation-timeline: --sheet-timeline;
+        animation-timeline: scroll();
       }
     }
 

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -218,9 +218,15 @@ export class BottomSheet extends HTMLElement {
       const matrix = new DOMMatrixReadOnly(style.transform);
       const yOffset = -matrix.m42;
       cleanupStyleProperties();
-      requestAnimationFrame(() => {
-        content.scrollTop = yOffset + content.scrollTop;
-      });
+      // Pin the sheet height inline so the content scrollTop update below is based
+      // on the correct scroll height. Removing [data-scrolling] reactivates the
+      // scroll-timeline-driven "expand-sheet-height" animation, which will not
+      // produce a current time until the next layout pass, leaving the sheet height
+      // (and content scroll height) stale for the scrollTop assignment that follows.
+      sheet.style.height = `${(this.scrollTop / (this.scrollHeight - this.offsetHeight)) * 100}%`;
+      content.scrollTop = yOffset + content.scrollTop;
+      // Clear the temporary inline override now that the scrollTop is set
+      sheet.style.height = "";
     };
 
     const handleScroll = () => {


### PR DESCRIPTION
## Description

Use animation-timeline: scroll() instead of referencing a named --sheet-timeline, since Firefox (with CSS scroll-driven animations enabled) cannot resolve a named scroll timeline on a host element from within its Shadow DOM (bug https://bugzilla.mozilla.org/show_bug.cgi?id=2021679). The named timeline is no longer set by the component — users who need one can define it on the host element themselves.

Also adds content-visibility: auto to .sheet-wrapper so Firefox properly renders sticky footers in [expand-to-scroll] mode despite contain: strict, and fixes handleScrollEnd to pin the sheet height inline during the scrollTop update since the scroll-timeline-driven animation no longer produces a current time immediately after removing [data-scrolling] due to using anonymous scroll timeline which is recreated during toggling and is stale until next layout pass (i.e., the inactive animation does not immediately update the sheet height).

## Checklist

- [x] My code follows the code guidelines of this project
