### PR TITLE
Fix snap-position-change events for content-height mode

### DIFF
--- a/examples/astro/src/pages/dynamic-height.astro
+++ b/examples/astro/src/pages/dynamic-height.astro
@@ -1,0 +1,166 @@
+---
+import Layout from "../layouts/Layout.astro";
+import DummyContent from "../components/DummyContent.astro";
+import { bottomSheetTemplate } from "pure-web-bottom-sheet/ssr";
+import SheetConfigPanel from "../components/SheetConfigPanel.astro";
+---
+
+<Layout>
+  <section>
+    <h1>Modal bottom sheet with dynamic height</h1>
+    <p>
+      This example demonstrates a bottom sheet with <code>content-height</code>
+      and dynamically added/removed content blocks. Each content block is
+      <code>10vh</code> tall, and the header and footer together are <code
+        >10vh</code
+      >tall in total, making the total sheet height <code>(N+1) * 10vh</code>
+      for N content blocks.
+    </p>
+    <p><button id="open-modal">Open sheet</button></p>
+    <pre id="log"></pre>
+  </section>
+  <SheetConfigPanel bottomSheetSelector="bottom-sheet.example" />
+  <DummyContent />
+
+  <bottom-sheet-dialog-manager>
+    <dialog id="bottom-sheet-dialog">
+      <bottom-sheet
+        class="example"
+        content-height
+        swipe-to-dismiss
+        tabindex="0"
+      >
+        <template shadowrootmode="open">
+          <Fragment set:html={bottomSheetTemplate} />
+        </template>
+
+        {/* Snap points */}
+        <div slot="snap" style="--snap: 100%" class="top"></div>
+        <div slot="snap" style="--snap: 75%"></div>
+        <div slot="snap" style="--snap: 50%" class="initial"></div>
+        <div slot="snap" style="--snap: 25%"></div>
+
+        <div slot="footer">
+          <button id="add-block">Add block</button>
+          <button id="remove-block">Remove block</button>
+        </div>
+
+        <div id="content-container"></div>
+      </bottom-sheet>
+    </dialog>
+  </bottom-sheet-dialog-manager>
+</Layout>
+
+<style is:global>
+  bottom-sheet.example {
+    --sheet-max-height: 100vh;
+  }
+  bottom-sheet::part(header),
+  bottom-sheet::part(footer) {
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+
+  bottom-sheet::part(header) {
+    height: 2.5vh;
+  }
+  bottom-sheet::part(footer) {
+    height: 7.5vh;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+  }
+
+  bottom-sheet h2 {
+    margin: 0;
+    text-align: center;
+  }
+
+  #log {
+    height: 150px;
+    overflow: scroll;
+    padding: 0.5rem;
+    border: 1px solid black;
+    font-size: 0.8rem;
+  }
+
+  .content-block {
+    height: 10vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .content-block:nth-child(odd) {
+    background-color: #c0c0c0;
+  }
+
+  .content-block:nth-child(even) {
+    background-color: #e0e0e0;
+  }
+</style>
+
+<script>
+  import {
+    registerSheetElements,
+    type SnapPositionChangeEventDetail,
+  } from "pure-web-bottom-sheet";
+  registerSheetElements();
+
+  const openModalButton = document.getElementById("open-modal");
+  const dialog = document.querySelector<HTMLDialogElement>(
+    "dialog#bottom-sheet-dialog",
+  );
+  openModalButton?.addEventListener("click", () => {
+    dialog?.showModal();
+  });
+
+  const container = document.getElementById("content-container");
+  const addButton = document.getElementById("add-block");
+  const removeButton = document.getElementById("remove-block");
+
+  let blockCount = 0;
+
+  function createBlock() {
+    blockCount++;
+    const block = document.createElement("div");
+    block.className = "content-block";
+    block.textContent = `Block ${blockCount}`;
+    container?.appendChild(block);
+  }
+
+  addButton?.addEventListener("click", () => {
+    createBlock();
+  });
+
+  removeButton?.addEventListener("click", () => {
+    const lastBlock = container?.lastElementChild;
+    if (lastBlock) {
+      lastBlock.remove();
+    }
+  });
+
+  const logElement = document.getElementById("log");
+  const log = (message: string) => {
+    console.log(message);
+    if (logElement) {
+      logElement.textContent += message + "\n";
+      logElement.scrollTop = logElement.scrollHeight;
+    }
+  };
+
+  dialog?.addEventListener("toggle", (e) => {
+    log(`Dialog toggled: ${e.newState}`);
+  });
+
+  const sheet = document.querySelector("bottom-sheet.example");
+  sheet?.addEventListener(
+    "snap-position-change",
+    (e: CustomEventInit<SnapPositionChangeEventDetail> & Event) => {
+      log(
+        `Snap position changed: index=${e.detail?.snapIndex}, state=${e.detail?.sheetState}`,
+      );
+    },
+  );
+</script>

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -59,6 +59,11 @@ import Layout from "../layouts/Layout.astro";
             >Modal bottom sheet with snap position change event listener</a
           >
         </li>
+        <li>
+          <a href=`${import.meta.env.BASE_URL}/dynamic-height/`
+            >Modal bottom sheet with dynamic height
+          </a>
+        </li>
       </ul>
     </section>
     <section>

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -50,12 +50,11 @@ const styles = css`
     top: calc(var(--snap) - 1px);
     margin-bottom: -1px; /* Compensate height so it does not affect layout */
     /*
-      The bottom sheet uses an IntersectionObserver as a fallback for browsers
-      that do not support the native scrollsnapchange event. The snap element
-      needs a bounding box that extends above the observer boundary (the scroll
-      container's top edge) so that these browsers reliably detect it as
-      intersecting when snapped. Without this, e.g., WebKit may report the element
-      as not-intersecting when it sits exactly at the boundary.
+      The bottom sheet uses an IntersectionObserver to dispatch custom snap-position-change
+      events. The snap element needs a bounding box that extends above the observer
+      boundary (the scroll container's top edge) so that these browsers reliably
+      detect it as intersecting when snapped. Without this, e.g., WebKit may report
+      the element as not-intersecting when it sits exactly at the boundary.
     */
     height: 1px;
   }

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -115,6 +115,10 @@ const styles = css`
         (var(--sheet-max-height) - min(100%, var(--sheet-max-height))) * -1 -
           1px
       );
+
+      :host(:not([content-height])) & {
+        display: none;
+      }
     }
   }
 

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -109,6 +109,13 @@ const styles = css`
     &[data-snap="bottom"] {
       top: 1px;
     }
+    &[data-snap="content-height"] {
+      position: absolute;
+      top: calc(
+        (var(--sheet-max-height) - min(100%, var(--sheet-max-height))) * -1 -
+          1px
+      );
+    }
   }
 
   .sheet-wrapper {
@@ -253,6 +260,16 @@ const styles = css`
 
     .sheet {
       min-height: 100%;
+    }
+  }
+
+  :host([content-height]) {
+    .sheet-wrapper {
+      /*
+        Needed to position the "content-height" sentinel at the correct position
+        relative to the sheet for accurate intersection observation.
+      */
+      position: relative;
     }
   }
 
@@ -457,6 +474,7 @@ export const template: string = /* HTML */ `
   <div class="snap snap-bottom" data-snap="bottom"></div>
   <div class="sentinel" data-snap="top"></div>
   <div class="sheet-wrapper">
+    <div class="sentinel" data-snap="content-height"></div>
     <aside class="sheet" part="sheet" data-snap="top">
       <header class="sheet-header" part="header">
         <div class="handle" part="handle"></div>

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -1,13 +1,6 @@
 import { template } from "./bottom-sheet.template";
 
 /**
- * @see https://drafts.csswg.org/css-scroll-snap-2/#snapevent-interface
- */
-interface SnapEvent extends Event {
-  snapTargetBlock: Element;
-}
-
-/**
  * @see https://drafts.csswg.org/scroll-animations/#scrolltimeline-interface
  */
 interface ScrollTimeline extends AnimationTimeline {
@@ -31,7 +24,7 @@ declare var ScrollTimeline: {
  * }
  */
 export class BottomSheet extends HTMLElement {
-  static observedAttributes = ["nested-scroll-optimization", "content-height"];
+  static observedAttributes = ["nested-scroll-optimization"];
   #handleViewportResize = () => {
     this.style.setProperty(
       "--sw-keyboard-height",
@@ -40,7 +33,6 @@ export class BottomSheet extends HTMLElement {
   };
   #shadow: ShadowRoot;
   #cleanupIntersectionObserver: (() => void) | null = null;
-  #cleanupSheetSizeObserver: (() => void) | null = null;
   #cleanupNestedScrollResizeOptimization: (() => void) | null = null;
   #currentSnapState: {
     snapIndex: number;
@@ -63,11 +55,6 @@ export class BottomSheet extends HTMLElement {
     }
     this.#shadow = shadow;
 
-    const supportsScrollSnapChange = "onscrollsnapchange" in window;
-    if (supportsScrollSnapChange) {
-      this.addEventListener("scrollsnapchange", this.#handleScrollSnapChange);
-    }
-
     if (
       !CSS.supports(
         "(animation-timeline: scroll()) and (animation-range: 0% 100%)",
@@ -79,10 +66,7 @@ export class BottomSheet extends HTMLElement {
   }
 
   connectedCallback() {
-    const supportsScrollSnapChange = "onscrollsnapchange" in window;
-    if (!supportsScrollSnapChange) {
-      this.#setupIntersectionObserver();
-    }
+    this.#setupIntersectionObserver();
 
     window.visualViewport?.addEventListener(
       "resize",
@@ -93,14 +77,16 @@ export class BottomSheet extends HTMLElement {
   #setupIntersectionObserver() {
     const snapSlot =
       this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
+
     const bottomSnapTarget = this.#shadow.querySelector(
       '.sentinel[data-snap="bottom"]',
     );
+
+    if (!snapSlot || !bottomSnapTarget) return;
+
     const contentHeightTarget = this.#shadow.querySelector(
       '.sentinel[data-snap="content-height"]',
     );
-
-    if (!snapSlot || !bottomSnapTarget || !contentHeightTarget) return;
 
     const intersectingTargets = new Set<Element>();
     let previousSnapTarget: Element | null = null;
@@ -140,15 +126,16 @@ export class BottomSheet extends HTMLElement {
           return;
         }
 
-        // Handle case where none of the targets intersect (fully collapsed state)
+        // No snap target within the bounds -> collapsed if the bottom sentinel has
+        // also exited (scrollTop at 0) and swipe-to-dismiss is enabled.
         if (!currentTarget) {
           if (
             intersectingTargets.has(bottomSnapTarget) ||
+            this.scrollTop > 1 ||
             !this.hasAttribute("swipe-to-dismiss")
           ) {
             return;
           }
-          // Use bottom target when nothing intersects and swipe-to-dismiss is enabled
           previousSnapTarget = bottomSnapTarget;
           this.#updateSnapPosition(bottomSnapTarget);
           return;
@@ -159,7 +146,7 @@ export class BottomSheet extends HTMLElement {
       },
       {
         root: this,
-        rootMargin: "1000% 0px -100% 0px",
+        rootMargin: "100% 0px -100% 0px",
       },
     );
 
@@ -176,6 +163,7 @@ export class BottomSheet extends HTMLElement {
       observedSnapPoints.forEach((el) => {
         if (!snapPoints.has(el)) {
           observer.unobserve(el);
+          intersectingTargets.delete(el);
         }
       });
 
@@ -191,14 +179,6 @@ export class BottomSheet extends HTMLElement {
       observer.disconnect();
       this.#cleanupIntersectionObserver = null;
     };
-  }
-
-  #handleScrollSnapChange(event: Event) {
-    const snapEvent = event as SnapEvent;
-    if (!(snapEvent.snapTargetBlock instanceof HTMLElement)) {
-      return;
-    }
-    this.#updateSnapPosition(snapEvent.snapTargetBlock);
   }
 
   #updateSnapPosition(newSnapTarget: Element) {
@@ -229,16 +209,6 @@ export class BottomSheet extends HTMLElement {
   #calculateSnapState(
     snapTarget: Element,
   ): { snapIndex: number; sheetState: SheetState } | null {
-    const snapSlot =
-      this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
-    if (!snapSlot) return null;
-
-    const assignedSnapPoints = snapSlot.assignedElements();
-
-    const hasTopSnapPoint =
-      assignedSnapPoints.at(0)?.classList.contains("top") ?? false;
-
-    // Snapped on the .snap.snap-bottom element
     if (
       snapTarget instanceof HTMLElement &&
       snapTarget.dataset.snap === "bottom"
@@ -246,44 +216,67 @@ export class BottomSheet extends HTMLElement {
       return { snapIndex: 0, sheetState: "collapsed" };
     }
 
-    // When content-height attribute is set, check if the sheet has reached its
-    // maximum height (based on its contents) and consider this as snapped to the
-    // expanded state and choose the snap index based on the closest snap point
-    // above the content height.
+    const snapSlot =
+      this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
+    if (!snapSlot) return null;
+
+    // Reverse to bottom-to-top order so array index maps to snap index (i + 1)
+    const assignedSnapPoints = snapSlot.assignedElements().reverse();
+
+    const hasTopSnapPoint =
+      assignedSnapPoints.at(-1)?.classList.contains("top") ?? false;
+
+    const maxExpandedIndex =
+      assignedSnapPoints.length + (hasTopSnapPoint ? 0 : 1);
+
+    // When content-height is set, the topmost reachable snap index may be
+    // lower than maxExpandedIndex (limited by how tall the content is).
+    let topmostReachableIndex = maxExpandedIndex;
     if (this.hasAttribute("content-height")) {
       const maxSheetHeight = Math.min(
         this.offsetHeight,
         this.scrollHeight - this.offsetHeight,
       );
-      // -1px tolerance for subpixel rounding
-      const hasReachedMaxHeight = this.scrollTop >= maxSheetHeight - 1;
+      let minHeightGap = Infinity;
 
-      const isContentHeightTarget =
+      for (let i = 0; i < assignedSnapPoints.length; i++) {
+        const el = assignedSnapPoints[i];
+        if (!(el instanceof HTMLElement)) continue;
+        // Add 1px to account for the -1px offset in CSS
+        const snapOffset = el.offsetTop + 1;
+        const heightGap = snapOffset - maxSheetHeight;
+        if (heightGap >= 0 && heightGap < minHeightGap) {
+          minHeightGap = heightGap;
+          topmostReachableIndex = i + 1;
+        }
+      }
+
+      // When snap target is the content-height sentinel, find the snap index from
+      // the current scroll position since the sentinel itself is not a snap point.
+      if (
         snapTarget instanceof HTMLElement &&
-        snapTarget.dataset.snap === "content-height";
-      if (hasReachedMaxHeight || isContentHeightTarget) {
-        let closestUnreachedSnapIndex = -1;
-        let closestDistance = Infinity;
-
+        snapTarget.dataset.snap === "content-height"
+      ) {
+        let closestSnapIndex = -1;
+        let minScrollGap = Infinity;
         for (let i = 0; i < assignedSnapPoints.length; i++) {
           const el = assignedSnapPoints[i];
           if (!(el instanceof HTMLElement)) continue;
           // Add 1px to account for the -1px offset in CSS
           const snapOffset = el.offsetTop + 1;
-          const distance = snapOffset - this.scrollTop;
-          if (distance >= 0 && distance < closestDistance) {
-            closestDistance = distance;
-            closestUnreachedSnapIndex = i;
+          const scrollGap = snapOffset - this.scrollTop;
+          if (scrollGap >= 0 && scrollGap < minScrollGap) {
+            minScrollGap = scrollGap;
+            closestSnapIndex = i + 1;
           }
         }
-
-        if (closestUnreachedSnapIndex !== -1) {
-          const snapIndex =
-            assignedSnapPoints.length - closestUnreachedSnapIndex;
-
+        if (closestSnapIndex !== -1) {
           return {
-            snapIndex,
-            sheetState: hasReachedMaxHeight ? "expanded" : "partially-expanded",
+            snapIndex: closestSnapIndex,
+            sheetState:
+              closestSnapIndex >= topmostReachableIndex
+                ? "expanded"
+                : "partially-expanded",
           };
         }
       }
@@ -291,16 +284,18 @@ export class BottomSheet extends HTMLElement {
 
     // Snapped on one of the snap points assigned to the "snap" slot
     if (snapTarget.matches('[slot="snap"]')) {
-      const position = assignedSnapPoints.indexOf(snapTarget);
-      const snapIndex = assignedSnapPoints.length - position;
-      const isTopSnapPoint = snapTarget.classList.contains("top");
-      const sheetState = isTopSnapPoint ? "expanded" : "partially-expanded";
-      return { snapIndex, sheetState };
+      const snapIndex = assignedSnapPoints.indexOf(snapTarget) + 1;
+      return {
+        snapIndex,
+        sheetState:
+          snapIndex >= topmostReachableIndex
+            ? "expanded"
+            : "partially-expanded",
+      };
     }
 
-    // Snapped either on the .sheet element or on the "snap" slot fallback element
-    const snapIndex = assignedSnapPoints.length + (hasTopSnapPoint ? 0 : 1);
-    return { snapIndex, sheetState: "expanded" };
+    // Snapped on the .sheet element or the "snap" slot fallback element
+    return { snapIndex: maxExpandedIndex, sheetState: "expanded" };
   }
 
   #handleScroll() {
@@ -467,31 +462,6 @@ export class BottomSheet extends HTMLElement {
     };
   }
 
-  #setupSheetSizeObserver() {
-    // Observe sheet size changes to re-dispatch the snap-position-change event
-    // in case the height change results in a different snap point being the closest
-    // one to the sheet top.
-    const resizeObserver = new ResizeObserver((e) => {
-      if (!e.at(0)?.contentBoxSize.at(0)?.blockSize) {
-        // Skip if the sheet has no height, i.e., when the sheet is closed or collapsed
-        return;
-      }
-      if (this.#currentSnapState) {
-        this.#updateSnapPosition(this.#currentSnapState.snapTarget);
-      }
-    });
-
-    const sheet = this.#shadow.querySelector<HTMLElement>(".sheet");
-    if (sheet) {
-      resizeObserver.observe(sheet);
-    }
-
-    this.#cleanupSheetSizeObserver = () => {
-      resizeObserver.disconnect();
-      this.#cleanupSheetSizeObserver = null;
-    };
-  }
-
   attributeChangedCallback(
     name: string,
     oldValue: string | null,
@@ -508,16 +478,6 @@ export class BottomSheet extends HTMLElement {
           }
         } else if (this.#cleanupNestedScrollResizeOptimization) {
           this.#cleanupNestedScrollResizeOptimization();
-        }
-        break;
-      case "content-height":
-        if (newValue !== null) {
-          if (!this.#cleanupSheetSizeObserver) {
-            // Only setup if not already setup
-            this.#setupSheetSizeObserver();
-          }
-        } else if (this.#cleanupSheetSizeObserver) {
-          this.#cleanupSheetSizeObserver();
         }
         break;
       default:

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -24,7 +24,7 @@ declare var ScrollTimeline: {
  * }
  */
 export class BottomSheet extends HTMLElement {
-  static observedAttributes = ["nested-scroll-optimization"];
+  static observedAttributes = ["nested-scroll-optimization", "content-height"];
   #handleViewportResize = () => {
     this.style.setProperty(
       "--sw-keyboard-height",
@@ -33,9 +33,13 @@ export class BottomSheet extends HTMLElement {
   };
   #shadow: ShadowRoot;
   #cleanupIntersectionObserver: (() => void) | null = null;
+  #cleanupSheetSizeObserver: (() => void) | null = null;
   #cleanupNestedScrollResizeOptimization: (() => void) | null = null;
-  #currentSnapState: { snapIndex: number; sheetState: SheetState } | null =
-    null;
+  #currentSnapState: {
+    snapIndex: number;
+    sheetState: SheetState;
+    snapTarget: Element;
+  } | null = null;
 
   constructor() {
     super();
@@ -190,7 +194,7 @@ export class BottomSheet extends HTMLElement {
       return;
     }
 
-    this.#currentSnapState = snapState;
+    this.#currentSnapState = { ...snapState, snapTarget: newSnapTarget };
     this.dataset.sheetState = sheetState;
 
     this.dispatchEvent(
@@ -458,6 +462,31 @@ export class BottomSheet extends HTMLElement {
     };
   }
 
+  #setupSheetSizeObserver() {
+    // Observe sheet size changes to re-dispatch the snap-position-change event
+    // in case the height change results in a different snap point being the closest
+    // one to the sheet top.
+    let previousBlockSize = 0;
+    const resizeObserver = new ResizeObserver((e) => {
+      const blockSize = e.at(0)?.contentBoxSize.at(0)?.blockSize ?? 0;
+      if (!blockSize || blockSize === previousBlockSize) return;
+      previousBlockSize = blockSize;
+      if (this.#currentSnapState) {
+        this.#updateSnapPosition(this.#currentSnapState.snapTarget);
+      }
+    });
+
+    const sheet = this.#shadow.querySelector<HTMLElement>(".sheet");
+    if (sheet) {
+      resizeObserver.observe(sheet);
+    }
+
+    this.#cleanupSheetSizeObserver = () => {
+      resizeObserver.disconnect();
+      this.#cleanupSheetSizeObserver = null;
+    };
+  }
+
   attributeChangedCallback(
     name: string,
     oldValue: string | null,
@@ -474,6 +503,16 @@ export class BottomSheet extends HTMLElement {
           }
         } else if (this.#cleanupNestedScrollResizeOptimization) {
           this.#cleanupNestedScrollResizeOptimization();
+        }
+        break;
+      case "content-height":
+        if (newValue !== null) {
+          if (!this.#cleanupSheetSizeObserver) {
+            // Only setup if not already setup
+            this.#setupSheetSizeObserver();
+          }
+        } else if (this.#cleanupSheetSizeObserver) {
+          this.#cleanupSheetSizeObserver();
         }
         break;
       default:

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -34,11 +34,8 @@ export class BottomSheet extends HTMLElement {
   #shadow: ShadowRoot;
   #cleanupIntersectionObserver: (() => void) | null = null;
   #cleanupNestedScrollResizeOptimization: (() => void) | null = null;
-  #currentSnapState: {
-    snapIndex: number;
-    sheetState: SheetState;
-    snapTarget: Element;
-  } | null = null;
+  #currentSnapState: { snapIndex: number; sheetState: SheetState } | null =
+    null;
 
   constructor() {
     super();
@@ -77,7 +74,6 @@ export class BottomSheet extends HTMLElement {
   #setupIntersectionObserver() {
     const snapSlot =
       this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
-
     const bottomSnapTarget = this.#shadow.querySelector(
       '.sentinel[data-snap="bottom"]',
     );
@@ -194,7 +190,7 @@ export class BottomSheet extends HTMLElement {
       return;
     }
 
-    this.#currentSnapState = { ...snapState, snapTarget: newSnapTarget };
+    this.#currentSnapState = snapState;
     this.dataset.sheetState = sheetState;
 
     this.dispatchEvent(

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -105,43 +105,38 @@ export class BottomSheet extends HTMLElement {
     const intersectingTargets = new Set<Element>();
     let previousSnapTarget: Element | null = null;
 
-    const getDistanceToSnapLine = (entry: IntersectionObserverEntry) =>
-      Math.abs(entry.intersectionRect.top - (entry.rootBounds?.bottom ?? 0));
-
     const observer = new IntersectionObserver(
       (entries) => {
-        // Add intersecting entries to the set sorted by proximity to the host's top
-        // which is the point where snapping occurs because we use `scroll-snap-align: start`
-        entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => {
-            return getDistanceToSnapLine(b) - getDistanceToSnapLine(a);
-          })
-          .forEach((entry) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
             intersectingTargets.add(entry.target);
-          });
-
-        entries
-          .filter((entry) => !entry.isIntersecting)
-          .forEach((entry) => {
+          } else {
             intersectingTargets.delete(entry.target);
-          });
+          }
+        });
 
         // Skip when the root has no dimensions (e.g., inside a closed dialog)
         if (!entries[0]?.rootBounds?.height) {
           return;
         }
 
-        // Skip bottom snap target (handled separately for collapsed state detection)
-        // and content height target if content-height attribute is unset
-        const skipContentHeightTarget = !this.hasAttribute("content-height");
-        const currentTarget = Array.from(intersectingTargets).findLast(
-          (target) =>
-            target !== bottomSnapTarget &&
-            (!skipContentHeightTarget || target !== contentHeightTarget),
-        );
+        // Pick the intersecting target closest to the snap line (host's top edge).
+        // Skip bottom snap target (handled separately for collapsed state detection).
+        const currentTarget = Array.from(intersectingTargets)
+          .filter((target) => target !== bottomSnapTarget)
+          .sort(
+            (a, b) =>
+              a.getBoundingClientRect().top - b.getBoundingClientRect().top,
+          )
+          .at(-1);
 
-        if (currentTarget === previousSnapTarget) {
+        if (
+          currentTarget === previousSnapTarget &&
+          // Never skip the "content-height" target even if it was the previous snap
+          // target, because the computed snap index may be different if the content
+          // height has changed since the last intersection update.
+          currentTarget !== contentHeightTarget
+        ) {
           return;
         }
 
@@ -251,20 +246,31 @@ export class BottomSheet extends HTMLElement {
       return { snapIndex: 0, sheetState: "collapsed" };
     }
 
-    // When content-height attribute is set, we must check if the sheet has reached
-    // maximum scroll top (i.e. the content height) and consider that as snapped
-    // to the expanded state and choose the snap index based on the closest snap
-    // point above the content height.
+    // When content-height attribute is set, check if the sheet has reached its
+    // maximum height (based on its contents) and consider this as snapped to the
+    // expanded state and choose the snap index based on the closest snap point
+    // above the content height.
     if (this.hasAttribute("content-height")) {
-      const maxScroll = this.scrollHeight - this.offsetHeight;
-      const hasReachedContentHeight = this.scrollTop >= maxScroll;
-      if (hasReachedContentHeight && assignedSnapPoints.length > 0) {
+      const maxSheetHeight = Math.min(
+        this.offsetHeight,
+        this.scrollHeight - this.offsetHeight,
+      );
+      // -1px tolerance for subpixel rounding
+      const hasReachedMaxHeight = this.scrollTop >= maxSheetHeight - 1;
+
+      const isContentHeightTarget =
+        snapTarget instanceof HTMLElement &&
+        snapTarget.dataset.snap === "content-height";
+      if (hasReachedMaxHeight || isContentHeightTarget) {
         let closestUnreachedSnapIndex = -1;
         let closestDistance = Infinity;
 
         for (let i = 0; i < assignedSnapPoints.length; i++) {
-          const snapPosition = (assignedSnapPoints[i] as HTMLElement).offsetTop;
-          const distance = snapPosition - this.scrollTop;
+          const el = assignedSnapPoints[i];
+          if (!(el instanceof HTMLElement)) continue;
+          // Add 1px to account for the -1px offset in CSS
+          const snapOffset = el.offsetTop + 1;
+          const distance = snapOffset - this.scrollTop;
           if (distance >= 0 && distance < closestDistance) {
             closestDistance = distance;
             closestUnreachedSnapIndex = i;
@@ -274,15 +280,12 @@ export class BottomSheet extends HTMLElement {
         if (closestUnreachedSnapIndex !== -1) {
           const snapIndex =
             assignedSnapPoints.length - closestUnreachedSnapIndex;
-          return { snapIndex, sheetState: "expanded" };
+
+          return {
+            snapIndex,
+            sheetState: hasReachedMaxHeight ? "expanded" : "partially-expanded",
+          };
         }
-      } else if (
-        snapTarget instanceof HTMLElement &&
-        snapTarget.dataset.snap === "content-height"
-      ) {
-        // The "content-height" sentinel cannot be used for snap state calculation
-        // when the content height has not been reached.
-        return null;
       }
     }
 
@@ -465,10 +468,14 @@ export class BottomSheet extends HTMLElement {
   }
 
   #setupSheetSizeObserver() {
-    // We need to observe size changes of the sheet to re-dispatch snap-position-change
-    // event in case the content height changes and causes a different snap point
-    // to be the closest one to the sheet top.
-    const resizeObserver = new ResizeObserver(() => {
+    // Observe sheet size changes to re-dispatch the snap-position-change event
+    // in case the height change results in a different snap point being the closest
+    // one to the sheet top.
+    const resizeObserver = new ResizeObserver((e) => {
+      if (!e.at(0)?.contentBoxSize.at(0)?.blockSize) {
+        // Skip if the sheet has no height, i.e., when the sheet is closed or collapsed
+        return;
+      }
       if (this.#currentSnapState) {
         this.#updateSnapPosition(this.#currentSnapState.snapTarget);
       }

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -31,7 +31,7 @@ declare var ScrollTimeline: {
  * }
  */
 export class BottomSheet extends HTMLElement {
-  static observedAttributes = ["nested-scroll-optimization"];
+  static observedAttributes = ["nested-scroll-optimization", "content-height"];
   #handleViewportResize = () => {
     this.style.setProperty(
       "--sw-keyboard-height",
@@ -40,9 +40,13 @@ export class BottomSheet extends HTMLElement {
   };
   #shadow: ShadowRoot;
   #cleanupIntersectionObserver: (() => void) | null = null;
+  #cleanupSheetSizeObserver: (() => void) | null = null;
   #cleanupNestedScrollResizeOptimization: (() => void) | null = null;
-  #currentSnapState: { snapIndex: number; sheetState: SheetState } | null =
-    null;
+  #currentSnapState: {
+    snapIndex: number;
+    sheetState: SheetState;
+    snapTarget: Element;
+  } | null = null;
 
   constructor() {
     super();
@@ -92,8 +96,11 @@ export class BottomSheet extends HTMLElement {
     const bottomSnapTarget = this.#shadow.querySelector(
       '.sentinel[data-snap="bottom"]',
     );
+    const contentHeightTarget = this.#shadow.querySelector(
+      '.sentinel[data-snap="content-height"]',
+    );
 
-    if (!snapSlot || !bottomSnapTarget) return;
+    if (!snapSlot || !bottomSnapTarget || !contentHeightTarget) return;
 
     const intersectingTargets = new Set<Element>();
     let previousSnapTarget: Element | null = null;
@@ -126,8 +133,12 @@ export class BottomSheet extends HTMLElement {
         }
 
         // Skip bottom snap target (handled separately for collapsed state detection)
+        // and content height target if content-height attribute is unset
+        const skipContentHeightTarget = !this.hasAttribute("content-height");
         const currentTarget = Array.from(intersectingTargets).findLast(
-          (target) => target !== bottomSnapTarget,
+          (target) =>
+            target !== bottomSnapTarget &&
+            (!skipContentHeightTarget || target !== contentHeightTarget),
         );
 
         if (currentTarget === previousSnapTarget) {
@@ -208,7 +219,7 @@ export class BottomSheet extends HTMLElement {
       return;
     }
 
-    this.#currentSnapState = snapState;
+    this.#currentSnapState = { ...snapState, snapTarget: newSnapTarget };
     this.dataset.sheetState = sheetState;
 
     this.dispatchEvent(
@@ -238,6 +249,41 @@ export class BottomSheet extends HTMLElement {
       snapTarget.dataset.snap === "bottom"
     ) {
       return { snapIndex: 0, sheetState: "collapsed" };
+    }
+
+    // When content-height attribute is set, we must check if the sheet has reached
+    // maximum scroll top (i.e. the content height) and consider that as snapped
+    // to the expanded state and choose the snap index based on the closest snap
+    // point above the content height.
+    if (this.hasAttribute("content-height")) {
+      const maxScroll = this.scrollHeight - this.offsetHeight;
+      const hasReachedContentHeight = this.scrollTop >= maxScroll;
+      if (hasReachedContentHeight && assignedSnapPoints.length > 0) {
+        let closestUnreachedSnapIndex = -1;
+        let closestDistance = Infinity;
+
+        for (let i = 0; i < assignedSnapPoints.length; i++) {
+          const snapPosition = (assignedSnapPoints[i] as HTMLElement).offsetTop;
+          const distance = snapPosition - this.scrollTop;
+          if (distance >= 0 && distance < closestDistance) {
+            closestDistance = distance;
+            closestUnreachedSnapIndex = i;
+          }
+        }
+
+        if (closestUnreachedSnapIndex !== -1) {
+          const snapIndex =
+            assignedSnapPoints.length - closestUnreachedSnapIndex;
+          return { snapIndex, sheetState: "expanded" };
+        }
+      } else if (
+        snapTarget instanceof HTMLElement &&
+        snapTarget.dataset.snap === "content-height"
+      ) {
+        // The "content-height" sentinel cannot be used for snap state calculation
+        // when the content height has not been reached.
+        return null;
+      }
     }
 
     // Snapped on one of the snap points assigned to the "snap" slot
@@ -418,6 +464,27 @@ export class BottomSheet extends HTMLElement {
     };
   }
 
+  #setupSheetSizeObserver() {
+    // We need to observe size changes of the sheet to re-dispatch snap-position-change
+    // event in case the content height changes and causes a different snap point
+    // to be the closest one to the sheet top.
+    const resizeObserver = new ResizeObserver(() => {
+      if (this.#currentSnapState) {
+        this.#updateSnapPosition(this.#currentSnapState.snapTarget);
+      }
+    });
+
+    const sheet = this.#shadow.querySelector<HTMLElement>(".sheet");
+    if (sheet) {
+      resizeObserver.observe(sheet);
+    }
+
+    this.#cleanupSheetSizeObserver = () => {
+      resizeObserver.disconnect();
+      this.#cleanupSheetSizeObserver = null;
+    };
+  }
+
   attributeChangedCallback(
     name: string,
     oldValue: string | null,
@@ -434,6 +501,16 @@ export class BottomSheet extends HTMLElement {
           }
         } else if (this.#cleanupNestedScrollResizeOptimization) {
           this.#cleanupNestedScrollResizeOptimization();
+        }
+        break;
+      case "content-height":
+        if (newValue !== null) {
+          if (!this.#cleanupSheetSizeObserver) {
+            // Only setup if not already setup
+            this.#setupSheetSizeObserver();
+          }
+        } else if (this.#cleanupSheetSizeObserver) {
+          this.#cleanupSheetSizeObserver();
         }
         break;
       default:

--- a/test/pageobjects/dynamic-height.page.ts
+++ b/test/pageobjects/dynamic-height.page.ts
@@ -1,0 +1,57 @@
+import BottomSheetComponent from "./bottom-sheet.component";
+import Page from "./page";
+
+class DynamicHeightPage extends Page {
+  bottomSheet = new BottomSheetComponent("bottom-sheet.example", {
+    P0: 0,
+    P25: 0.25,
+    P50: 0.5,
+    P75: 0.75,
+    P100: 1,
+  });
+
+  get dialog() {
+    return $("#bottom-sheet-dialog");
+  }
+
+  get openButton() {
+    return $("#open-modal");
+  }
+
+  get addBlockButton() {
+    return $("#add-block");
+  }
+
+  get removeBlockButton() {
+    return $("#remove-block");
+  }
+
+  open() {
+    return super.open("dynamic-height");
+  }
+
+  async openDialog() {
+    await this.openButton.waitForClickable();
+    await this.openButton.click();
+    // Wait for the initial-snap animation on the bottom sheet to finish so all
+    // snap points are active
+    await this.bottomSheet.waitForSnapPointsToActivate();
+    // Wait for the dialog open transition to complete to ensure the sheet is fully
+    // open before interacting with it
+    await this.dialog.waitForAnimationsToFinish();
+  }
+
+  async addBlocks(count: number) {
+    for (let i = 0; i < count; i++) {
+      await this.addBlockButton.click();
+    }
+  }
+
+  async removeBlocks(count: number) {
+    for (let i = 0; i < count; i++) {
+      await this.removeBlockButton.click();
+    }
+  }
+}
+
+export default new DynamicHeightPage();

--- a/test/specs/bottom-sheet.snap-position-change.e2e.ts
+++ b/test/specs/bottom-sheet.snap-position-change.e2e.ts
@@ -403,6 +403,25 @@ describe("Bottom sheet snap-position-change event", function () {
       const events = await getCapturedSnapEvents();
       expect(events).toEqual([{ sheetState: "collapsed", snapIndex: 0 }]);
     });
+
+    it("should update sheetState when content grows past the current snap point", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(4);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P50);
+      await waitForSnapEvent(2, "expanded");
+      await clearCapturedSnapEvents();
+
+      await DynamicHeightPage.addBlocks(1);
+
+      await waitForSnapEvent(2, "partially-expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([
+        { sheetState: "partially-expanded", snapIndex: 2 },
+      ]);
+    });
   });
 
   describe("sheet without swipe-to-dismiss", function () {

--- a/test/specs/bottom-sheet.snap-position-change.e2e.ts
+++ b/test/specs/bottom-sheet.snap-position-change.e2e.ts
@@ -3,6 +3,7 @@ import type {
   SheetState,
 } from "pure-web-bottom-sheet";
 import DialogPage from "../pageobjects/dialog.page";
+import DynamicHeightPage from "../pageobjects/dynamic-height.page";
 import EventsPage from "../pageobjects/events.page";
 import NonDismissiblePage from "../pageobjects/non-dismissible.page";
 
@@ -43,23 +44,21 @@ describe("Bottom sheet snap-position-change event", function () {
     snapIndex: number,
     sheetState: SheetState,
   ) => {
-    let lastEvent: SnapPositionChangeEventDetail | undefined;
-    await browser.waitUntil(
-      async () => {
-        lastEvent = (await getCapturedSnapEvents()).at(-1);
-        return (
-          lastEvent?.snapIndex === snapIndex &&
-          lastEvent?.sheetState === sheetState
-        );
-      },
-      {
-        timeoutMsg:
-          `Expected last snap event to be ` +
+    await browser.waitUntil(async () => {
+      const lastEvent = (await getCapturedSnapEvents()).at(-1);
+      if (
+        lastEvent?.snapIndex === snapIndex &&
+        lastEvent?.sheetState === sheetState
+      ) {
+        return true;
+      }
+      throw new Error(
+        `Expected last snap event to be ` +
           `{snapIndex: ${snapIndex}, ` +
           `sheetState: "${sheetState}"}, ` +
           `but was ${JSON.stringify(lastEvent)}`,
-      },
-    );
+      );
+    });
   };
 
   describe("sheet with explicit top snap point", function () {
@@ -275,6 +274,134 @@ describe("Bottom sheet snap-position-change event", function () {
       await waitForSnapEvent(2, "expanded");
       const events = await getCapturedSnapEvents();
       expect(events).toEqual([{ sheetState: "expanded", snapIndex: 2 }]);
+    });
+  });
+
+  describe("sheet with content-height and dynamic content blocks", function () {
+    // On the dynamic height page, user can add or remove content blocks to the
+    // sheet contents. Each block is 10vh, and the header and footer themselves
+    // are 10vh in total). So N blocks corresponds to (N + 1) * 10vh content height.
+    const sheet = DynamicHeightPage.bottomSheet;
+    const snapPoints = sheet.snapPoints;
+
+    beforeEach(async function () {
+      await DynamicHeightPage.open();
+      await addSnapPositionChangeListener();
+      await DynamicHeightPage.openDialog();
+      await expect(DynamicHeightPage.dialog).toBeDisplayed();
+      await expect(sheet.host).toBeDisplayed();
+    });
+
+    it("should fire 'expanded' at snap index 1 with minimal content (0 blocks, 10vh)", async function () {
+      // 0 blocks = 10vh content (max height between P0 and P25)
+      await waitForSnapEvent(1, "expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([{ sheetState: "expanded", snapIndex: 1 }]);
+    });
+
+    it("should fire 'expanded' at snap index 2 when content grows past P25 (2 blocks, 30vh)", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(2);
+      // Scroll to a known position and clear events to avoid browser-dependent
+      // intermediate snap events fired while blocks are added.
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await clearCapturedSnapEvents();
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P50);
+      await waitForSnapEvent(2, "expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([{ sheetState: "expanded", snapIndex: 2 }]);
+    });
+
+    it("should fire 'expanded' at snap index 3 when content grows past P50 (5 blocks, 60vh)", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(5);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await clearCapturedSnapEvents();
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P75);
+      await waitForSnapEvent(3, "expanded");
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P50);
+      await waitForSnapEvent(2, "partially-expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([
+        { sheetState: "expanded", snapIndex: 3 },
+        { sheetState: "partially-expanded", snapIndex: 2 },
+      ]);
+    });
+
+    it("should fire 'expanded' at snap index 4 when content grows past P75 (8 blocks, 90vh)", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(8);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await clearCapturedSnapEvents();
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P100);
+      await waitForSnapEvent(4, "expanded");
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P75);
+      await waitForSnapEvent(3, "partially-expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([
+        { sheetState: "expanded", snapIndex: 4 },
+        { sheetState: "partially-expanded", snapIndex: 3 },
+      ]);
+    });
+
+    it("should fire 'expanded' at snap index 4 when content reaches full height (9 blocks, 100vh)", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(9);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await clearCapturedSnapEvents();
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P100);
+      await waitForSnapEvent(4, "expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([{ sheetState: "expanded", snapIndex: 4 }]);
+    });
+
+    it("should lower the expanded snap index when content shrinks (8 blocks down to 2)", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(8);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P100);
+      await waitForSnapEvent(4, "expanded");
+
+      // Remove 6 blocks (back to 30vh content, between P25 and P50)
+      await DynamicHeightPage.removeBlocks(6);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P25);
+      await waitForSnapEvent(1, "partially-expanded");
+      await clearCapturedSnapEvents();
+
+      // P50 should now be the expanded position (snap index 2)
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P50);
+      await waitForSnapEvent(2, "expanded");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([{ sheetState: "expanded", snapIndex: 2 }]);
+    });
+
+    it("should fire 'collapsed' when scrolling to P0", async function () {
+      await waitForSnapEvent(1, "expanded");
+      await DynamicHeightPage.addBlocks(4);
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P50);
+      await waitForSnapEvent(2, "expanded");
+      await clearCapturedSnapEvents();
+
+      await sheet.setScrollTopRelativeToHeight(snapPoints.P0);
+      await waitForSnapEvent(0, "collapsed");
+
+      const events = await getCapturedSnapEvents();
+      expect(events).toEqual([{ sheetState: "collapsed", snapIndex: 0 }]);
     });
   });
 


### PR DESCRIPTION
## Description

- Fix `snap-position-change` events reporting incorrect `snapIndex` and `sheetState` when
  `content-height` is set and sheet content is dynamically added/removed
- Unify snap detection to use `IntersectionObserver` for all browsers, replacing the
  `scrollsnapchange` event path which reported inconsistent targets during fast scrolling
  between different snap points, particularly when using keyboard arrows
- Add a content-height sentinel element that tracks where the sheet's content boundary
  intersects the observation area, enabling accurate snap index calculation relative to
  actual content height
- Add `ResizeObserver` on the sheet to re-evaluate snap state when content height changes
  (e.g., growing past the current snap point updates `sheetState` from `expanded` to
  `partially-expanded`)

Other changes:

- Reduce IntersectionObserver `rootMargin` from `1000%` to `100%`
- Add `scrollTop > 1` guard to prevent false "collapsed" events during scroll transitions
- Clean up stale entries from `intersectingTargets` when snap points are dynamically removed
- Add dynamic-height example page and e2e tests for content-height scenarios

Fixes #16

## Checklist

- [x] My code follows the code guidelines of this project
- [x] Add tests
- [x] See if the code can be simplified somehow
