### PR TITLE
Add mouse-drag attribute for mouse pointer-based sheet dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,13 @@ using the bottom sheet as an overlay that should always remain visible.
   > - the `<bottom-sheet>` is placed inside a `<dialog>` wrapped
   >   in `bottom-sheet-dialog-manager` element
   > - using the Popover API (`popover` attribute on the bottom-sheet).
+- **`mouse-drag`**  
+  Enables dragging the sheet with the mouse to scroll between snap points. Touch
+  input already scrolls natively and is unaffected by this attribute. The attribute
+  value controls which part of the sheet is draggable:
+  - No value / empty string (boolean attribute): drag from header and footer
+  - `"header"`: drag from header only
+  - `"sheet"`: drag from anywhere in the sheet
 
 #### Slots
 

--- a/examples/astro/src/components/SheetConfigPanel.astro
+++ b/examples/astro/src/components/SheetConfigPanel.astro
@@ -41,6 +41,12 @@ const { bottomSheetSelector = "bottom-sheet" } = Astro.props;
           nestedScrollOptimization: bottomSheet.hasAttribute(
             "nested-scroll-optimization",
           ),
+          mouseDrag: (() => {
+            const val = bottomSheet.getAttribute("mouse-drag");
+            if (val === null) return "off";
+            if (val === "" || val === "true") return "";
+            return val;
+          })(),
         };
 
         const pane = new Pane({
@@ -60,6 +66,15 @@ const { bottomSheetSelector = "bottom-sheet" } = Astro.props;
           label: "Content height",
         });
         pane.addBinding(params, "nestedScroll", { label: "Nested scroll" });
+        pane.addBinding(params, "mouseDrag", {
+          label: "Mouse drag",
+          options: {
+            Off: "off",
+            "Header + Footer": "",
+            "Header only": "header",
+            "Full sheet": "sheet",
+          },
+        });
 
         const nestedScrollFolder = pane.addFolder({
           title: "Options specific to nested scroll",
@@ -111,6 +126,12 @@ const { bottomSheetSelector = "bottom-sheet" } = Astro.props;
             if (enabled) bottomSheet.setAttribute(attr, "");
             else bottomSheet.removeAttribute(attr);
           });
+
+          if (params.mouseDrag === "off") {
+            bottomSheet.removeAttribute("mouse-drag");
+          } else {
+            bottomSheet.setAttribute("mouse-drag", params.mouseDrag);
+          }
 
           if (params.alwaysStopAtSnapPoints) {
             bottomSheet.classList.add("snap-stop-always");

--- a/src/web/bottom-sheet.template.ts
+++ b/src/web/bottom-sheet.template.ts
@@ -276,6 +276,51 @@ const styles = css`
     }
   }
 
+  :host([mouse-drag]) {
+    scroll-behavior: smooth;
+
+    .sheet {
+      cursor: auto;
+    }
+
+    .sheet-header,
+    .sheet-footer {
+      cursor: grab;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    &:host([mouse-drag="header"]) .sheet-footer {
+      cursor: auto;
+      user-select: auto;
+      -webkit-user-select: auto;
+    }
+
+    &:host([mouse-drag="sheet"]) .sheet {
+      cursor: grab;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    &:host([data-mouse-dragging]) {
+      scroll-behavior: auto;
+      --snap-point-align: none;
+      user-select: none;
+      -webkit-user-select: none;
+
+      .snap.initial,
+      ::slotted([slot="snap"].initial) {
+        --snap-point-align: none;
+      }
+
+      .sheet,
+      .sheet-header,
+      .sheet-footer {
+        cursor: grabbing;
+      }
+    }
+  }
+
   :host([nested-scroll]) {
     .sheet-wrapper {
       display: flex;

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -24,7 +24,11 @@ declare var ScrollTimeline: {
  * }
  */
 export class BottomSheet extends HTMLElement {
-  static observedAttributes = ["nested-scroll-optimization", "content-height"];
+  static observedAttributes = [
+    "nested-scroll-optimization",
+    "content-height",
+    "mouse-drag",
+  ];
   #handleViewportResize = () => {
     this.style.setProperty(
       "--sw-keyboard-height",
@@ -35,6 +39,7 @@ export class BottomSheet extends HTMLElement {
   #cleanupIntersectionObserver: (() => void) | null = null;
   #cleanupSheetSizeObserver: (() => void) | null = null;
   #cleanupNestedScrollResizeOptimization: (() => void) | null = null;
+  #cleanupMouseDrag: (() => void) | null = null;
   #currentSnapState: {
     snapIndex: number;
     sheetState: SheetState;
@@ -359,6 +364,10 @@ export class BottomSheet extends HTMLElement {
     };
 
     const handleScrollEnd = () => {
+      // Skip during mouse drag because each programmatic scrollTop assignment
+      // triggers scrollend, which would clear data-scrolling prematurely.
+      if ("mouseDragging" in this.dataset) return;
+
       const style = getComputedStyle(content);
       const matrix = new DOMMatrixReadOnly(style.transform);
       const yOffset = -matrix.m42;
@@ -487,6 +496,87 @@ export class BottomSheet extends HTMLElement {
     };
   }
 
+  #setupMouseDrag() {
+    const sheet = this.#shadow.querySelector<HTMLElement>(".sheet");
+    if (!sheet) return;
+
+    const header = this.#shadow.querySelector<HTMLElement>(".sheet-header");
+    const footer = this.#shadow.querySelector<HTMLElement>(".sheet-footer");
+
+    const DRAG_THRESHOLD = 10;
+
+    let startY = 0;
+    let startScrollTop = 0;
+
+    const cleanupDrag = () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
+      delete this.dataset.mouseDragging;
+    };
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse" || e.button !== 0) return;
+
+      const dragMode = this.getAttribute("mouse-drag");
+      if (dragMode !== "sheet") {
+        const path = e.composedPath();
+        const targets = dragMode === "header" ? [header] : [header, footer];
+        if (!targets.some((el) => el && path.includes(el))) return;
+      }
+
+      startY = e.pageY;
+      startScrollTop = this.scrollTop;
+
+      document.addEventListener("pointermove", handlePointerMove);
+      document.addEventListener("pointerup", handlePointerUp);
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse") return;
+      if (!(e.buttons & 1)) {
+        cleanupDrag();
+        return;
+      }
+      const deltaY = e.pageY - startY;
+      if (!("mouseDragging" in this.dataset)) {
+        if (Math.abs(deltaY) < DRAG_THRESHOLD) return;
+        this.dataset.mouseDragging = "";
+        sheet.setPointerCapture(e.pointerId);
+      }
+      this.scrollTop = startScrollTop - deltaY;
+    };
+
+    const handlePointerUp = (e: PointerEvent) => {
+      if (e.pointerType !== "mouse" || e.button !== 0) return;
+
+      const shouldSuppressClick = "mouseDragging" in this.dataset;
+      cleanupDrag();
+
+      // Suppress the click that follows a drag. Needed for WebKit where
+      // pointer capture alone does not prevent clicks on the original target.
+      if (shouldSuppressClick) {
+        sheet.addEventListener(
+          "click",
+          (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          },
+          { capture: true, once: true },
+        );
+      }
+    };
+
+    sheet.addEventListener("pointerdown", handlePointerDown);
+    sheet.addEventListener("pointercancel", cleanupDrag);
+
+    this.#cleanupMouseDrag = () => {
+      sheet.removeEventListener("pointerdown", handlePointerDown);
+      sheet.removeEventListener("pointercancel", cleanupDrag);
+      cleanupDrag();
+      this.#cleanupMouseDrag = null;
+    };
+  }
+
   attributeChangedCallback(
     name: string,
     oldValue: string | null,
@@ -513,6 +603,15 @@ export class BottomSheet extends HTMLElement {
           }
         } else if (this.#cleanupSheetSizeObserver) {
           this.#cleanupSheetSizeObserver();
+        }
+        break;
+      case "mouse-drag":
+        if (newValue !== null) {
+          if (!this.#cleanupMouseDrag) {
+            this.#setupMouseDrag();
+          }
+        } else if (this.#cleanupMouseDrag) {
+          this.#cleanupMouseDrag();
         }
         break;
       default:
@@ -555,6 +654,15 @@ export interface BottomSheetHTMLAttributes {
    * with the `bottom-sheet-dialog-manager` or with the Popover API.
    */
   ["swipe-to-dismiss"]?: boolean;
+  /**
+   * When set, enables dragging the sheet with the mouse to scroll between snap
+   * points. Touch input already scrolls natively and is unaffected by this attribute.
+   *
+   * - No value (boolean): drag from header and footer
+   * - `"header"`: drag from header only
+   * - `"sheet"`: drag from anywhere in the sheet
+   */
+  ["mouse-drag"]?: boolean | "header" | "sheet";
 }
 
 /**

--- a/test/pageobjects/bottom-sheet.component.ts
+++ b/test/pageobjects/bottom-sheet.component.ts
@@ -21,6 +21,14 @@ export default class BottomSheetComponent<
     return this.host.shadow$('[part="header"]');
   }
 
+  get content() {
+    return this.host.shadow$('[part="content"]');
+  }
+
+  get footer() {
+    return this.host.shadow$('[part="footer"]');
+  }
+
   get sheetSurface() {
     return this.host.shadow$('[part="sheet"]');
   }

--- a/test/specs/bottom-sheet.mouse-drag.e2e.ts
+++ b/test/specs/bottom-sheet.mouse-drag.e2e.ts
@@ -1,0 +1,231 @@
+import NonDismissiblePage from "../pageobjects/non-dismissible.page";
+
+declare global {
+  interface Window {
+    __mouseDraggingDetected?: boolean;
+  }
+}
+
+describe("Mouse drag", function () {
+  const sheet = NonDismissiblePage.bottomSheet;
+  const snapPoints = sheet.snapPoints;
+
+  /**
+   * Simulates a mouse drag gesture.
+   * Uses viewport coordinates so the drag distance is exact regardless of
+   * element movement during the drag.
+   */
+  async function mouseDrag(
+    target: ChainablePromiseElement,
+    deltaY: number,
+    options: {
+      numSteps?: number;
+      startOffset?: { x?: number; y?: number };
+      skipRelease?: boolean;
+    } = {},
+  ) {
+    const { numSteps = 5, startOffset, skipRelease = false } = options;
+
+    const location = await target.getLocation();
+    const size = await target.getSize();
+    const startX = Math.round(location.x + (startOffset?.x ?? size.width / 2));
+    const startY = Math.round(
+      Math.max(location.y + (startOffset?.y ?? size.height / 2), 0),
+    );
+
+    const action = browser
+      .action("pointer", { parameters: { pointerType: "mouse" } })
+      .move({ x: startX, y: startY, origin: "viewport" })
+      .down();
+
+    for (let i = 1; i <= numSteps; i++) {
+      action.move({
+        x: startX,
+        y: Math.round(startY + (deltaY * i) / numSteps),
+        origin: "viewport",
+        duration: 50,
+      });
+    }
+
+    if (!skipRelease) {
+      action.up();
+    }
+
+    await action.perform(skipRelease);
+  }
+
+  beforeEach(async function () {
+    await NonDismissiblePage.open();
+    await expect(sheet.host).toBeExisting();
+    await sheet.waitForSnapPointsToActivate();
+    await sheet.host.execute((el) => el.setAttribute("mouse-drag", ""));
+  });
+
+  describe("default mode (header + footer)", function () {
+    it("should drag up from header to expand sheet", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.header, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should drag down from header to shrink sheet", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.header, 150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P25);
+    });
+
+    it("should drag from footer", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.footer, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should not drag from content area", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.content, -150, { startOffset: { y: 10 } });
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+    });
+  });
+
+  describe('header mode (mouse-drag="header")', function () {
+    beforeEach(async function () {
+      await sheet.host.execute((el) => el.setAttribute("mouse-drag", "header"));
+    });
+
+    it("should drag from header", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.header, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should not drag from footer", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.footer, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+    });
+  });
+
+  describe('sheet mode (mouse-drag="sheet")', function () {
+    beforeEach(async function () {
+      await sheet.host.execute((el) => el.setAttribute("mouse-drag", "sheet"));
+    });
+
+    it("should drag from content area", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.content, -150, { startOffset: { y: 10 } });
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should drag from header", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.header, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should drag from footer", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await mouseDrag(sheet.footer, -150);
+
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+  });
+
+  describe("click interaction", function () {
+    beforeEach(async function () {
+      await sheet.host.execute((el) => el.setAttribute("mouse-drag", "sheet"));
+      // Expand sheet so the details element is visible and not covered by footer
+      await sheet.scrollByRelativeToHeight(0.5);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P100);
+    });
+
+    it("should allow clicking elements inside drag area", async function () {
+      const details = $("bottom-sheet.example details");
+      // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
+      await expect(details).toHaveElementProperty("open", true);
+
+      await details.$("summary").click();
+
+      // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
+      await expect(details).toHaveElementProperty("open", false);
+    });
+
+    it("should suppress click after drag", async function () {
+      const details = $("bottom-sheet.example details");
+      // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
+      await expect(details).toHaveElementProperty("open", true);
+
+      await mouseDrag(details.$("summary"), -150, { startOffset: { y: 10 } });
+
+      // details.open should remain unchanged since the click was suppressed
+      // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
+      await expect(details).toHaveElementProperty("open", true);
+    });
+
+    it("should clear dragging state when pointer is canceled before pointerup", async function () {
+      await mouseDrag(sheet.header, 40, { skipRelease: true });
+      await expect(sheet.host).toHaveAttribute("data-mouse-dragging");
+
+      await sheet.sheetSurface.execute((surface) => {
+        surface.dispatchEvent(new Event("pointercancel"));
+      });
+
+      await expect(sheet.host).not.toHaveAttribute(
+        "data-mouse-dragging",
+        undefined,
+        { wait: 0 },
+      );
+
+      await browser
+        .action("pointer", { parameters: { pointerType: "mouse" } })
+        .up()
+        .perform();
+    });
+  });
+
+  describe("touch interaction", function () {
+    it("should not set data-mouse-dragging during touch scroll", async function () {
+      if (!browser.isChromium) {
+        // Only Chromium-based browsers support touch emulation.
+        this.skip();
+      }
+
+      // Track if data-mouse-dragging is ever set via MutationObserver
+      await sheet.host.execute((el) => {
+        window.__mouseDraggingDetected = false;
+        new MutationObserver(() => {
+          if ((el as HTMLElement).hasAttribute("data-mouse-dragging")) {
+            window.__mouseDraggingDetected = true;
+          }
+        }).observe(el, {
+          attributes: true,
+          attributeFilter: ["data-mouse-dragging"],
+        });
+      });
+
+      await browser.touchFlingInTarget(50, 500, sheet.header, "up");
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+
+      const detected = await browser.execute(
+        () => window.__mouseDraggingDetected ?? false,
+      );
+      expect(detected).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Introduces the `mouse-drag` attribute that enables dragging the bottom sheet with a mouse between snap points. Touch input is unaffected as it already scrolls natively. The attribute supports three modes:

- Boolean (no value): drag from header and footer
- "header": drag from header only
- "sheet": drag from anywhere in the sheet

Includes CSS cursor/select styles, pointer capture with a 10px drag threshold, click suppression after drags, and e2e tests covering all modes, and click passthrough.

Fixes #15

## Checklist

- [x] My code follows the code guidelines of this project
