### PR TITLE
Add snapToPoint method for programmatic snapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,21 +500,22 @@ using the bottom sheet as an overlay that should always remain visible.
 #### Methods
 
 - **`snapToPoint(index: number, options?: { behavior?: ScrollBehavior }): void`**  
-  Scrolls the bottom sheet to the snap point at the given snap index. The index
-  follows the same convention as the `snapIndex` reported by the
-  `snap-position-change` event:
-  - `0` corresponds to the collapsed state (only reachable when the
-    `swipe-to-dismiss` attribute is set).
-  - Values from `1` up to the maximum expanded index correspond to the snap
-    points assigned to the `snap` slot, ordered from bottom to top.
-  - The maximum expanded index corresponds to the fully expanded state.
+  Scrolls the bottom sheet to the snap point at the given snap index, using
+  the same convention as the `snap-position-change` event's `snapIndex`.
+  Indices range from `0` (collapsed) to the maximum (fully expanded), with
+  intermediate values mapping to user-defined snap points in bottom-to-top
+  order.
+
+  If the index is not an integer or is out of range, does nothing. Otherwise,
+  the final position is determined by the browser's scroll-snap, so for
+  example index `0` without `swipe-to-dismiss` resolves to the bottommost
+  reachable snap point, and indices beyond the `content-height` limit resolve
+  to the topmost reachable snap.
 
   The `options.behavior` field maps directly to the `behavior` option of the
   underlying [`Element.scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)
   call (`"auto"` | `"instant"` | `"smooth"`). When omitted, the browser default
   is used.
-
-  If the index is not an integer or is out of range, does nothing.
 
   When using the React or Vue wrapper, obtain a typed reference to the
   underlying element via the `BottomSheetElement` type re-exported from the

--- a/README.md
+++ b/README.md
@@ -497,6 +497,65 @@ using the bottom sheet as an overlay that should always remain visible.
   - `"expanded"` - The bottom sheet is fully expanded (i.e., snapped to the full
     height).
 
+#### Methods
+
+- **`snapToPoint(index: number, options?: { behavior?: ScrollBehavior }): void`**  
+  Scrolls the bottom sheet to the snap point at the given snap index. The index
+  follows the same convention as the `snapIndex` reported by the
+  `snap-position-change` event:
+  - `0` corresponds to the collapsed state (only reachable when the
+    `swipe-to-dismiss` attribute is set).
+  - Values from `1` up to the maximum expanded index correspond to the snap
+    points assigned to the `snap` slot, ordered from bottom to top.
+  - The maximum expanded index corresponds to the fully expanded state.
+
+  The `options.behavior` field maps directly to the `behavior` option of the
+  underlying [`Element.scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)
+  call (`"auto"` | `"instant"` | `"smooth"`). When omitted, the browser default
+  is used.
+
+  If the index is not an integer or is out of range, does nothing.
+
+  When using the React or Vue wrapper, obtain a typed reference to the
+  underlying element via the `BottomSheetElement` type re-exported from the
+  framework subpath:
+
+  ```tsx
+  // React
+  import { useRef } from "react";
+  import {
+    BottomSheet,
+    type BottomSheetElement,
+  } from "pure-web-bottom-sheet/react";
+
+  function Example() {
+    const sheet = useRef<BottomSheetElement>(null);
+    return (
+      <BottomSheet ref={sheet}>
+        <button onClick={() => sheet.current?.snapToPoint(2)}>Snap to 2</button>
+      </BottomSheet>
+    );
+  }
+  ```
+
+  ```vue
+  <!-- Vue -->
+  <template>
+    <VBottomSheet ref="sheet">
+      <button @click="sheet?.snapToPoint(2)">Snap to 2</button>
+    </VBottomSheet>
+  </template>
+  <script setup lang="ts">
+  import { useTemplateRef } from "vue";
+  import {
+    VBottomSheet,
+    type BottomSheetElement,
+  } from "pure-web-bottom-sheet/vue";
+
+  const sheet = useTemplateRef<BottomSheetElement>("sheet");
+  </script>
+  ```
+
 ### `<bottom-sheet-dialog-manager>`: A utility element for the native `<dialog>` element to use the `<bottom-sheet>` element as a dialog
 
 The `<bottom-sheet-dialog-manager>` element is used when the bottom sheet should

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -64,6 +64,11 @@ import Layout from "../layouts/Layout.astro";
             >Modal bottom sheet with dynamic height
           </a>
         </li>
+        <li>
+          <a href=`${import.meta.env.BASE_URL}/snap-to-point/`
+            >Programmatic snapping with <code>snapToPoint()</code>
+          </a>
+        </li>
       </ul>
     </section>
     <section>

--- a/examples/astro/src/pages/snap-to-point.astro
+++ b/examples/astro/src/pages/snap-to-point.astro
@@ -1,0 +1,125 @@
+---
+import Layout from "../layouts/Layout.astro";
+import DummyContent from "../components/DummyContent.astro";
+import { bottomSheetTemplate } from "pure-web-bottom-sheet/ssr";
+import SheetConfigPanel from "../components/SheetConfigPanel.astro";
+---
+
+<Layout>
+  <section>
+    <h1>Programmatic snapping with snapToPoint()</h1>
+    <p>
+      This example demonstrates the public <code
+        >snapToPoint(index: number)</code
+      >
+      method. The index follows the same convention as the
+      <code>snap-position-change</code> event's <code>snapIndex</code>: <code
+        >0</code
+      > is collapsed (only reachable when <code>swipe-to-dismiss</code> is set), and
+      the maximum index corresponds to the fully expanded state.
+    </p>
+    <p>
+      <label>
+        Scroll behavior:
+        <select id="behavior-select">
+          <option value="auto" selected>auto</option>
+          <option value="instant">instant</option>
+          <option value="smooth">smooth</option>
+        </select>
+      </label>
+    </p>
+    <p>
+      Current state: <code id="current-state">unknown</code>
+    </p>
+  </section>
+  <SheetConfigPanel bottomSheetSelector="bottom-sheet.example" />
+  <DummyContent />
+
+  <bottom-sheet class="example" tabindex="0">
+    <template shadowrootmode="open">
+      <Fragment set:html={bottomSheetTemplate} />
+    </template>
+
+    {/* Snap points */}
+    <div slot="snap" style="--snap: 75%"></div>
+    <div slot="snap" style="--snap: 50%" class="initial"></div>
+    <div slot="snap" style="--snap: 25%"></div>
+
+    <div slot="header">
+      <h2>snapToPoint example</h2>
+    </div>
+
+    <div slot="footer">
+      <small>Snap to point</small>
+      <button data-snap-index="1" title="25%">1</button>
+      <button data-snap-index="2" title="50%">2</button>
+      <button data-snap-index="3" title="75%">3</button>
+      <button data-snap-index="4" title="fully expanded">4</button>
+    </div>
+
+    <p>
+      Use the buttons in the footer to programmatically scroll the sheet to a
+      snap point. With three user-defined snap points (and no <code>.top</code> snap
+      point), the maximum expanded index is <code>4</code>, which corresponds to
+      the fully expanded state.
+    </p>
+    <details open>
+      <summary>Dummy content</summary>
+      <DummyContent />
+    </details>
+  </bottom-sheet>
+</Layout>
+
+<style>
+  bottom-sheet.example h2 {
+    margin: 0.5em 0;
+    text-align: center;
+  }
+
+  bottom-sheet.example [slot="footer"] {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+
+    small {
+      flex-basis: 100%;
+      text-align: center;
+    }
+  }
+</style>
+
+<script>
+  import {
+    BottomSheet,
+    type SnapPositionChangeEventDetail,
+  } from "pure-web-bottom-sheet";
+  customElements.define("bottom-sheet", BottomSheet);
+
+  const sheet = document.querySelector<BottomSheet>("bottom-sheet.example");
+  const behaviorSelect =
+    document.querySelector<HTMLSelectElement>("#behavior-select");
+  if (sheet) {
+    document
+      .querySelectorAll<HTMLButtonElement>("[data-snap-index]")
+      .forEach((button) => {
+        button.addEventListener("click", () => {
+          const index = Number(button.dataset.snapIndex);
+          sheet.snapToPoint(index, {
+            behavior: behaviorSelect?.value as ScrollBehavior | undefined,
+          });
+        });
+      });
+
+    const stateEl = document.getElementById("current-state");
+    sheet.addEventListener(
+      "snap-position-change",
+      (e: CustomEventInit<SnapPositionChangeEventDetail> & Event) => {
+        if (stateEl && e.detail) {
+          stateEl.textContent = `snapIndex=${e.detail.snapIndex} state=${e.detail.sheetState}`;
+        }
+      },
+    );
+  }
+</script>

--- a/examples/react-nextjs/pages/non-dismissible-with-pages-router.tsx
+++ b/examples/react-nextjs/pages/non-dismissible-with-pages-router.tsx
@@ -1,10 +1,14 @@
-import { BottomSheet } from "pure-web-bottom-sheet/react";
+import {
+  BottomSheet,
+  type BottomSheetElement,
+} from "pure-web-bottom-sheet/react";
 import DummyContent from "../components/DummyContent";
 import "../app/global.css";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export default function Page() {
   const [, setHasMounted] = useState(false);
+  const sheetRef = useRef<BottomSheetElement>(null);
 
   useEffect(() => {
     // Workaround for React 19 hydration bug: Forces a re-render after mount to ensure
@@ -22,6 +26,7 @@ export default function Page() {
       </section>
       <DummyContent />
       <BottomSheet
+        ref={sheetRef}
         tabIndex={0}
         onsnap-position-change={(e) =>
           console.log("Snap position changed:", e.detail)
@@ -33,8 +38,28 @@ export default function Page() {
         <div slot="header">
           <h2>Custom header</h2>
         </div>
-        <div slot="footer">
-          <h2>Custom footer</h2>
+        <div
+          slot="footer"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: "0.5rem",
+            padding: "0.5rem",
+          }}
+        >
+          <small style={{ flexBasis: "100%", textAlign: "center" }}>
+            Snap to point
+          </small>
+          {[1, 2, 3, 4].map((index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => sheetRef.current?.snapToPoint(index)}
+            >
+              {index}
+            </button>
+          ))}
         </div>
 
         <DummyContent />

--- a/examples/vue-nuxt/app/pages/non-dismissible.vue
+++ b/examples/vue-nuxt/app/pages/non-dismissible.vue
@@ -3,6 +3,7 @@
     <h1>Non-dismissible bottom sheet</h1>
     <DummyContent />
     <VBottomSheet
+      ref="sheet"
       class="example"
       tabindex="0"
       @snap-position-change="callback"
@@ -13,7 +14,15 @@
         <h2>Custom header</h2>
       </div>
       <div slot="footer">
-        <h2>Custom footer</h2>
+        <small>Snap to point</small>
+        <button
+          v-for="index in [1, 2, 3, 4]"
+          :key="index"
+          type="button"
+          @click="sheet?.snapToPoint(index)"
+        >
+          {{ index }}
+        </button>
       </div>
       <div slot="snap" style="--snap: 75%"></div>
       <div slot="snap" style="--snap: 50%" class="initial"></div>
@@ -23,8 +32,14 @@
   </section>
 </template>
 <script setup lang="ts">
-import { VBottomSheet } from "pure-web-bottom-sheet/vue";
-import type { SnapPositionChangeEventDetail } from "pure-web-bottom-sheet";
+import { useTemplateRef } from "vue";
+import {
+  VBottomSheet,
+  type BottomSheetElement,
+  type SnapPositionChangeEventDetail,
+} from "pure-web-bottom-sheet/vue";
+
+const sheet = useTemplateRef<BottomSheetElement>("sheet");
 
 const callback = (event: CustomEvent<SnapPositionChangeEventDetail>) => {
   console.log("Snap position changed:", event.detail);
@@ -35,5 +50,18 @@ const callback = (event: CustomEvent<SnapPositionChangeEventDetail>) => {
 bottom-sheet.example h2 {
   margin: 0.5em 0;
   text-align: center;
+}
+
+bottom-sheet.example [slot="footer"] {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+
+  small {
+    flex-basis: 100%;
+    text-align: center;
+  }
 }
 </style>

--- a/src/react/BottomSheet.tsx
+++ b/src/react/BottomSheet.tsx
@@ -1,4 +1,7 @@
-import { BottomSheetHTMLAttributes } from "../web/bottom-sheet";
+import {
+  BottomSheet as BottomSheetWebElement,
+  BottomSheetHTMLAttributes,
+} from "../web/bottom-sheet";
 import { BottomSheetEvents } from "../web/index.client";
 import { bottomSheetTemplate } from "../web/index.ssr";
 import Client from "./Client";
@@ -7,7 +10,8 @@ import ShadowRootTemplate from "./ShadowRootTemplate";
 
 type BottomSheetProps = CustomElementProps<
   BottomSheetHTMLAttributes,
-  BottomSheetEvents
+  BottomSheetEvents,
+  BottomSheetWebElement
 >;
 
 declare module "react/jsx-runtime" {

--- a/src/react/custom-element-props.ts
+++ b/src/react/custom-element-props.ts
@@ -14,6 +14,7 @@ type EventsToReactProps<ElementEvents extends EventMap> = {
 export type CustomElementProps<
   ElementHTMLAttributes = {},
   ElementEvents extends EventMap = {},
-> = React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> &
+  Element extends HTMLElement = HTMLElement,
+> = React.DetailedHTMLProps<React.HTMLAttributes<Element>, Element> &
   ElementHTMLAttributes &
   EventsToReactProps<ElementEvents>;

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -2,3 +2,24 @@ import BottomSheet from "./BottomSheet";
 import BottomSheetDialogManager from "./BottomSheetDialogManager";
 
 export { BottomSheet, BottomSheetDialogManager };
+
+/**
+ * Type alias for the underlying `BottomSheet` web component element. Use this
+ * to type a `ref` so that public methods like `snapToPoint(index)` are
+ * accessible from the ref.
+ *
+ * @example
+ * import { useRef } from "react";
+ * import { BottomSheet, type BottomSheetElement } from "pure-web-bottom-sheet/react";
+ *
+ * const ref = useRef<BottomSheetElement>(null);
+ * ref.current?.snapToPoint(2);
+ */
+export type { BottomSheet as BottomSheetElement } from "../web/bottom-sheet";
+
+export type {
+  SheetState,
+  SnapPositionChangeEventDetail,
+  BottomSheetEvents,
+  SnapToPointOptions,
+} from "../web/bottom-sheet";

--- a/src/vue/custom-element-props.ts
+++ b/src/vue/custom-element-props.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "vue";
+import { HTMLAttributes, VNodeProps } from "vue";
 
 type CamelCase<S extends string> =
   S extends `${infer P1}-${infer P2}${infer P3}`
@@ -33,4 +33,5 @@ export type CustomElementProps<
   ElementEvents extends EventMap = {},
 > = KeysToCamelCase<ElementHTMLAttributes> &
   HTMLAttributes &
+  VNodeProps &
   EventsToVueProps<ElementEvents>;

--- a/src/vue/custom-element-props.ts
+++ b/src/vue/custom-element-props.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes, VNodeProps } from "vue";
+import { HTMLAttributes, PublicProps } from "vue";
 
 type CamelCase<S extends string> =
   S extends `${infer P1}-${infer P2}${infer P3}`
@@ -33,5 +33,5 @@ export type CustomElementProps<
   ElementEvents extends EventMap = {},
 > = KeysToCamelCase<ElementHTMLAttributes> &
   HTMLAttributes &
-  VNodeProps &
+  PublicProps &
   EventsToVueProps<ElementEvents>;

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,2 +1,23 @@
 export { default as VBottomSheet } from "./VBottomSheet";
 export { default as VBottomSheetDialogManager } from "./VBottomSheetDialogManager";
+
+/**
+ * Type alias for the underlying `BottomSheet` web component element. Use this
+ * to type a template ref so that public methods like `snapToPoint(index)` are
+ * accessible from the ref.
+ *
+ * @example
+ * import { useTemplateRef } from "vue";
+ * import { VBottomSheet, type BottomSheetElement } from "pure-web-bottom-sheet/vue";
+ *
+ * const sheet = useTemplateRef<BottomSheetElement>("sheet");
+ * sheet.value?.snapToPoint(2);
+ */
+export type { BottomSheet as BottomSheetElement } from "../web/bottom-sheet";
+
+export type {
+  SheetState,
+  SnapPositionChangeEventDetail,
+  BottomSheetEvents,
+  SnapToPointOptions,
+} from "../web/bottom-sheet";

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -75,6 +75,63 @@ export class BottomSheet extends HTMLElement {
     );
   }
 
+  /**
+   * Scrolls the bottom sheet to the snap point at the given snap index.
+   *
+   * If the index is not an integer or is out of range, does nothing.
+   *
+   * @param index - The snap index to scroll to. Follows the same convention as
+   *   the `snap-position-change` event's `snapIndex`:
+   *   - `0` corresponds to the collapsed state (only reachable when
+   *     `swipe-to-dismiss` is set).
+   *   - Values from `1` up to the maximum expanded index correspond to the
+   *     snap points assigned to the `snap` slot, ordered from bottom to top.
+   *   - The maximum expanded index corresponds to the fully expanded state.
+   * @param options - Options that control how the scroll is performed.
+   */
+  snapToPoint(index: number, options?: SnapToPointOptions) {
+    const snapPoints = this.#getSnapPoints();
+    if (!snapPoints) return;
+    const { assignedSnapPoints, maxExpandedIndex } = snapPoints;
+
+    if (!Number.isInteger(index) || index < 0 || index > maxExpandedIndex) {
+      return;
+    }
+
+    let target: Element | null;
+    if (index === maxExpandedIndex) {
+      target = this.#shadow.querySelector(".sheet");
+    } else if (index === 0) {
+      target = this.#shadow.querySelector(".snap-bottom");
+    } else {
+      target = assignedSnapPoints[index - 1] ?? null;
+    }
+
+    target?.scrollIntoView({ behavior: options?.behavior });
+  }
+
+  /**
+   * Returns the snap points assigned to the `snap` slot, ordered bottom-to-top
+   * so that array index maps to snap index (`i + 1`), along with the maximum
+   * expanded snap index. Returns `null` when the `snap` slot is missing.
+   */
+  #getSnapPoints(): {
+    assignedSnapPoints: Element[];
+    maxExpandedIndex: number;
+  } | null {
+    const snapSlot =
+      this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
+    if (!snapSlot) return null;
+
+    const assignedSnapPoints = snapSlot.assignedElements().reverse();
+    const hasTopSnapPoint =
+      assignedSnapPoints.at(-1)?.classList.contains("top") ?? false;
+    const maxExpandedIndex =
+      assignedSnapPoints.length + (hasTopSnapPoint ? 0 : 1);
+
+    return { assignedSnapPoints, maxExpandedIndex };
+  }
+
   #setupIntersectionObserver() {
     const snapSlot =
       this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
@@ -216,18 +273,9 @@ export class BottomSheet extends HTMLElement {
       return { snapIndex: 0, sheetState: "collapsed" };
     }
 
-    const snapSlot =
-      this.#shadow.querySelector<HTMLSlotElement>('slot[name="snap"]');
-    if (!snapSlot) return null;
-
-    // Reverse to bottom-to-top order so array index maps to snap index (i + 1)
-    const assignedSnapPoints = snapSlot.assignedElements().reverse();
-
-    const hasTopSnapPoint =
-      assignedSnapPoints.at(-1)?.classList.contains("top") ?? false;
-
-    const maxExpandedIndex =
-      assignedSnapPoints.length + (hasTopSnapPoint ? 0 : 1);
+    const snapPoints = this.#getSnapPoints();
+    if (!snapPoints) return null;
+    const { assignedSnapPoints, maxExpandedIndex } = snapPoints;
 
     // When content-height is set, the topmost reachable snap index may be
     // lower than maxExpandedIndex (limited by how tall the content is).
@@ -527,6 +575,19 @@ export class BottomSheet extends HTMLElement {
       this.#handleViewportResize,
     );
   }
+}
+
+/**
+ * Options for the {@link BottomSheet.snapToPoint} method.
+ */
+export interface SnapToPointOptions {
+  /**
+   * Determines whether scrolling is instant or animates smoothly. Maps directly
+   * to the `behavior` option of the underlying
+   * [`Element.scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)
+   * call.
+   */
+  behavior?: ScrollBehavior;
 }
 
 export interface BottomSheetHTMLAttributes {

--- a/src/web/bottom-sheet.ts
+++ b/src/web/bottom-sheet.ts
@@ -76,17 +76,19 @@ export class BottomSheet extends HTMLElement {
   }
 
   /**
-   * Scrolls the bottom sheet to the snap point at the given snap index.
+   * Scrolls the bottom sheet to the snap point at the given snap index, using
+   * the same convention as the `snap-position-change` event's `snapIndex`.
+   * Indices range from `0` (collapsed) to the maximum (fully expanded), with
+   * intermediate values mapping to user-defined snap points in bottom-to-top
+   * order.
    *
    * If the index is not an integer or is out of range, does nothing.
+   * Otherwise, the final position is determined by the browser's scroll-snap,
+   * so for example index `0` without `swipe-to-dismiss` resolves to the
+   * bottommost reachable snap point, and indices beyond the `content-height`
+   * limit resolve to the topmost reachable snap.
    *
-   * @param index - The snap index to scroll to. Follows the same convention as
-   *   the `snap-position-change` event's `snapIndex`:
-   *   - `0` corresponds to the collapsed state (only reachable when
-   *     `swipe-to-dismiss` is set).
-   *   - Values from `1` up to the maximum expanded index correspond to the
-   *     snap points assigned to the `snap` slot, ordered from bottom to top.
-   *   - The maximum expanded index corresponds to the fully expanded state.
+   * @param index - The snap index to scroll to.
    * @param options - Options that control how the scroll is performed.
    */
   snapToPoint(index: number, options?: SnapToPointOptions) {

--- a/src/web/index.client.ts
+++ b/src/web/index.client.ts
@@ -7,6 +7,7 @@ export type {
   SheetState,
   SnapPositionChangeEventDetail,
   BottomSheetEvents,
+  SnapToPointOptions,
 } from "./bottom-sheet";
 
 export function registerSheetElements() {

--- a/test/pageobjects/bottom-sheet.component.ts
+++ b/test/pageobjects/bottom-sheet.component.ts
@@ -1,3 +1,5 @@
+import type { BottomSheet } from "pure-web-bottom-sheet";
+
 export default class BottomSheetComponent<
   T extends Record<string, number> = Record<string, number>,
 > {
@@ -41,6 +43,18 @@ export default class BottomSheetComponent<
     await this.host.execute((el, scrollTop) => {
       el.scrollTop = scrollTop as number;
     }, targetScrollTop);
+  }
+
+  /** Calls `snapToPoint(index, { behavior })` on the bottom sheet host element. */
+  async callSnapToPoint(index: number, behavior?: ScrollBehavior) {
+    const host = await this.host.getElement();
+    return host.execute(
+      (el, i, b) => {
+        (el as BottomSheet).snapToPoint(i, b ? { behavior: b } : undefined);
+      },
+      index,
+      behavior,
+    );
   }
 
   /** Waits for all snap points to become active after the initial snap animation. */

--- a/test/pageobjects/snap-to-point.page.ts
+++ b/test/pageobjects/snap-to-point.page.ts
@@ -1,0 +1,17 @@
+import BottomSheetComponent from "./bottom-sheet.component";
+import Page from "./page";
+
+class SnapToPointPage extends Page {
+  bottomSheet = new BottomSheetComponent("bottom-sheet.example", {
+    P25: 0.25,
+    P50: 0.5,
+    P75: 0.75,
+    P100: 1,
+  });
+
+  open() {
+    return super.open("snap-to-point");
+  }
+}
+
+export default new SnapToPointPage();

--- a/test/specs/bottom-sheet.snap-to-point.e2e.ts
+++ b/test/specs/bottom-sheet.snap-to-point.e2e.ts
@@ -1,0 +1,81 @@
+import DialogPage from "../pageobjects/dialog.page";
+import SnapToPointPage from "../pageobjects/snap-to-point.page";
+
+describe("Bottom sheet snapToPoint()", function () {
+  describe("non-dismissible sheet", function () {
+    const sheet = SnapToPointPage.bottomSheet;
+    const snapPoints = sheet.snapPoints;
+
+    beforeEach(async function () {
+      await SnapToPointPage.open();
+      await expect(sheet.host).toBeExisting();
+      // Wait for the initial-snap animation to finish before invoking the API
+      await sheet.waitForSnapPointsToActivate();
+    });
+
+    it("should start at the initial 50% snap point", async function () {
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+    });
+
+    it("should snap to each user-defined snap point by index", async function () {
+      await sheet.callSnapToPoint(1);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P25);
+
+      await sheet.callSnapToPoint(2);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+
+      await sheet.callSnapToPoint(3);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should snap to fully expanded state at the maximum index", async function () {
+      // With 3 user-defined snap points and no `.top` snap point, the maximum
+      // expanded index is 4, which internally scrolls the `.sheet` element into
+      // view rather than any assigned snap point.
+      await sheet.callSnapToPoint(4);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P100);
+    });
+
+    it("should silently no-op for out-of-bounds index", async function () {
+      // Stays at the initial 50% snap point
+      await sheet.callSnapToPoint(-1);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+      await sheet.callSnapToPoint(5);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+    });
+
+    it("should silently no-op for non-integer index", async function () {
+      await sheet.callSnapToPoint(1.5);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+      await sheet.callSnapToPoint(NaN);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
+    });
+
+    it("should reach the target snap position when behavior is 'instant'", async function () {
+      await sheet.callSnapToPoint(3, "instant");
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+
+    it("should reach the target snap position when behavior is 'smooth'", async function () {
+      await sheet.callSnapToPoint(3, "smooth");
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
+    });
+  });
+
+  describe("modal dialog sheet (swipe-to-dismiss)", function () {
+    const sheet = DialogPage.bottomSheet;
+
+    beforeEach(async function () {
+      await DialogPage.open();
+      await DialogPage.openDialog();
+    });
+
+    it("should close the dialog when called with index 0", async function () {
+      await sheet.callSnapToPoint(0);
+      // The bottom-sheet-dialog-manager closes the dialog when the sheet snaps
+      // to the bottom (snapIndex 0), so no close animation here.
+      // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
+      await expect(DialogPage.dialog).toHaveElementProperty("open", false);
+    });
+  });
+});

--- a/test/specs/bottom-sheet.snap-to-point.e2e.ts
+++ b/test/specs/bottom-sheet.snap-to-point.e2e.ts
@@ -1,4 +1,5 @@
 import DialogPage from "../pageobjects/dialog.page";
+import DynamicHeightPage from "../pageobjects/dynamic-height.page";
 import SnapToPointPage from "../pageobjects/snap-to-point.page";
 
 describe("Bottom sheet snapToPoint()", function () {
@@ -60,6 +61,15 @@ describe("Bottom sheet snapToPoint()", function () {
       await sheet.callSnapToPoint(3, "smooth");
       await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P75);
     });
+
+    it("should resolve index 0 to the bottommost reachable snap point", async function () {
+      // The non-dismissible sheet has no `swipe-to-dismiss`, so index 0
+      // (collapsed) is not actually a point the sheet can snap to. Instead,
+      // the browser snaps the sheet to the bottommost reachable snap point,
+      // which is the 25% snap in this case.
+      await sheet.callSnapToPoint(0);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P25);
+    });
   });
 
   describe("modal dialog sheet (swipe-to-dismiss)", function () {
@@ -76,6 +86,31 @@ describe("Bottom sheet snapToPoint()", function () {
       // to the bottom (snapIndex 0), so no close animation here.
       // @ts-expect-error - toHaveElementProperty types only accept string values, not boolean
       await expect(DialogPage.dialog).toHaveElementProperty("open", false);
+    });
+  });
+
+  describe("content-height sheet", function () {
+    const sheet = DynamicHeightPage.bottomSheet;
+    const snapPoints = sheet.snapPoints;
+
+    beforeEach(async function () {
+      await DynamicHeightPage.open();
+      await DynamicHeightPage.openDialog();
+    });
+
+    it("should resolve indices beyond the content-limited max to the topmost reachable snap point", async function () {
+      // 4 content blocks (50vh) cap the maximum reachable scroll position
+      // at the 50% snap point.
+      await DynamicHeightPage.addBlocks(4);
+
+      await sheet.callSnapToPoint(1);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P25);
+
+      // callSnapToPoint(4) targets the .top user snap (100%) which is
+      // beyond the content-height limit. The browser snaps the sheet to
+      // the topmost reachable snap point, which is the 50% snap in this case.
+      await sheet.callSnapToPoint(4);
+      await expect(sheet.host).toHaveScrollTopRelativeToHeight(snapPoints.P50);
     });
   });
 });


### PR DESCRIPTION
## Description

Adds new `snapToPoint(index, options?)` method on the BottomSheet web component, with a `behavior` option mirroring `scrollIntoView`. Out-of-range or non-integer indices silently no-op. Adds a `BottomSheetElement` type re-export from the React/Vue wrappers for typed refs, an Astro `snap-to-point` example with a behavior selector, snap buttons in the existing non-dismissible React/Vue examples, and e2e tests.

Fixes #19 

## Checklist

- [x] My code follows the code guidelines of this project
