### PR TITLE
Pin e2e workflow to Node 24 to avoid WebdriverIO failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version-file: "package.json"
+          # Pin to Node 24 (LTS): WebdriverIO is broken on Node 26.
+          # Revert to node-version-file once webdriverio/webdriverio#15265 is fixed.
+          node-version: "24"
           check-latest: true
 
       - run: npm ci


### PR DESCRIPTION
## Description

WebdriverIO is broken on Node 26 (webdriverio/webdriverio#15265). To be reverted once the upstream issue is fixed.

## Checklist

- [x] My code follows the code guidelines of this project
